### PR TITLE
LL4 IMU Updates from Limelight OS 2025.1

### DIFF
--- a/yall/java/limelight/networktables/LimelightSettings.java
+++ b/yall/java/limelight/networktables/LimelightSettings.java
@@ -64,6 +64,10 @@ public class LimelightSettings
    */
   private NetworkTableEntry imuMode;
   /**
+   * Imu Assist Alpha value for the Limelight 4.
+   */
+  private NetworkTableEntry imuAssistAlpha;
+  /**
    * Sets 3d offset point for easy 3d targeting Sets the 3D point-of-interest offset for the current fiducial pipeline.
    * <p>
    * https://docs.limelightvision.io/docs/docs-limelight/pipeline-apriltag/apriltag-3d#point-of-interest-tracking
@@ -109,6 +113,7 @@ public class LimelightSettings
     streamMode = limelightTable.getEntry("stream");
     cropWindow = limelightTable.getDoubleArrayTopic("crop").getEntry(new double[0]);
     imuMode = limelightTable.getEntry("imumode_set");
+    imuAssistAlpha = limelightTable.getEntry("imuassistalpha_set");
     robotOrientationSet = limelightTable.getDoubleArrayTopic("robot_orientation_set").getEntry(new double[0]);
     downscale = limelightTable.getEntry("fiducial_downscale_set");
     fiducial3DOffset = limelightTable.getDoubleArrayTopic("fiducial_offset_set").getEntry(new double[0]);
@@ -194,6 +199,20 @@ public class LimelightSettings
   public LimelightSettings withImuMode(ImuMode mode)
   {
     imuMode.setNumber(mode.ordinal());
+    return this;
+  }
+
+  /**
+   * Set the IMU Assist filter alpha/strength value. Higher values will cause the internal imu to converge on
+   * assist source more rapidly.
+   * <p> This method changes the Limelight - normally immediately.
+   *
+   * @param alpha Assist alpha value (0.001 by default).
+   * @return {@link LimelightSettings} for chaining.
+   */
+  public LimelightSettings withImuAssistAlpha(double alpha)
+  {
+    imuAssistAlpha.setNumber(alpha);
     return this;
   }
 

--- a/yall/python/yall/limelight.py
+++ b/yall/python/yall/limelight.py
@@ -749,6 +749,9 @@ class LimelightSettings:
         self.imuMode: ntcore.NetworkTableEntry = self.limelightTable.getEntry(
             "imumode_set"
         )
+        self.imuAssistAlpha: ntcore.NetworkTableEntry = self.limelightTable.getEntry(
+            "imuassistalpha_set"
+        )
         self.robotOrientationSet: ntcore.DoubleArrayEntry = (
             self.limelightTable.getDoubleArrayTopic("robot_orientation_set").getEntry(
                 []
@@ -803,6 +806,15 @@ class LimelightSettings:
     def withImuMode(self, mode: ImuMode) -> "LimelightSettings":
         """Set the IMU Mode for the Limelight."""
         self.imuMode.setDouble(mode.value)
+        return self
+
+    def withImuAssistAlpha(self, alpha: float) -> "LimelightSettings":
+        """
+        Set the IMU Assist filter alpha/strength value.
+        Higher values will cause the internal imu to converge on assist source more rapidly.
+        Default value is 0.001.
+        """
+        self.imuAssistAlpha.setDouble(alpha)
         return self
 
     def withRobotOrientation(self, orientation: Orientation3d) -> "LimelightSettings":


### PR DESCRIPTION
- Add 2 missing ImuMode enum values
- Add missing Imu Assist Alpha NT setter "imuassistalpha_set"

Going to need help with the javadocs!  Wasn't able to regenerate them for myself